### PR TITLE
Fix SBF/BBF plotting bug for reforge methods

### DIFF
--- a/R/scatterer_reforge.R
+++ b/R/scatterer_reforge.R
@@ -327,7 +327,7 @@ setGeneric(
   component_rpos
 }
 
-#' Express an internal component centerline offset relative to parent thickness
+#' Express an internal component z-origin offset relative to parent thickness
 #' @param component_rpos Row-major internal-component position matrix.
 #' @param parent_rpos Row-major parent-component position matrix.
 #' @keywords internal
@@ -362,21 +362,19 @@ setGeneric(
   )
   component_center <- .reforge_profile_centerline(component_fields)
 
-  # Store a robust median offset ratio so it can be reconstructed later =======
-  valid <- is.finite(parent_half_height) &
-    (abs(parent_half_height) > sqrt(.Machine$double.eps))
-  if (!any(valid)) {
+  # Store the internal component z-origin relative to the parent profile ======
+  valid <- is.finite(parent_center[1]) &
+    is.finite(parent_half_height[1]) &
+    is.finite(component_center[1]) &
+    (abs(parent_half_height[1]) > sqrt(.Machine$double.eps))
+  if (!isTRUE(valid)) {
     return(0)
   }
 
-  stats::median(
-    (component_center[valid] - parent_center[valid]) /
-      parent_half_height[valid],
-    na.rm = TRUE
-  )
+  (component_center[1] - parent_center[1]) / parent_half_height[1]
 }
 
-#' Reposition an internal component to preserve relative vertical placement
+#' Reposition an internal component to preserve relative z-origin placement
 #' @param component_rpos Row-major internal-component position matrix.
 #' @param relative_offset Relative centerline offset scaled by parent half-height.
 #' @param parent_rpos Row-major parent-component position matrix.
@@ -418,10 +416,16 @@ setGeneric(
     .reforge_profile_half_height(parent_fields)
   )
   current_center <- .reforge_profile_centerline(component_fields)
-  target_center <- parent_center + relative_offset * parent_half_height
-  delta <- target_center - current_center
+  target_origin <- parent_center[1] + relative_offset * parent_half_height[1]
+  current_origin <- current_center[1]
+  if (!is.finite(target_origin) || !is.finite(current_origin)) {
+    return(component_rpos)
+  }
+  delta <- target_origin - current_origin
 
-  # Shift every vertical coordinate row by the reconstructed centerline delta ==
+  # Shift every vertical coordinate row by one component-level displacement.
+  # A nodewise displacement forces the internal component to inherit the body
+  # centerline profile and changes the component shape during reforge.
   z_idx <- .reforge_profile_row_idx(component_rpos, c("z", "z_body", "z_bladder"))
   zU_idx <- .reforge_profile_row_idx(
     component_rpos,

--- a/R/utilities-plotting.R
+++ b/R/utilities-plotting.R
@@ -595,6 +595,11 @@
     cex.axis = 1.2
   )
   graphics::lines(primary$x, -primary$half_width, lty = 1, lwd = 4)
+  graphics::segments(
+    x0 = primary$x, x1 = primary$x,
+    y0 = -primary$half_width, y1 = primary$half_width,
+    lty = 3, lwd = 1, col = "gray30"
+  )
 
   if (!is.null(secondary)) {
     graphics::lines(
@@ -604,6 +609,11 @@
     graphics::lines(
       secondary$x, -secondary$half_width,
       lty = 1, lwd = 3.5, col = secondary_col
+    )
+    graphics::segments(
+      x0 = secondary$x, x1 = secondary$x,
+      y0 = -secondary$half_width, y1 = secondary$half_width,
+      lty = 3, lwd = 1, col = secondary_col
     )
   }
 

--- a/tests/testthat/test-scatterer_reforge.R
+++ b/tests/testthat/test-scatterer_reforge.R
@@ -1158,6 +1158,37 @@ test_that("`reforge('SBF')` scales the body centerline without warping", {
   expect_equal(diff(range(center)) / max(half), orig_ratio, tolerance = 1e-8)
 })
 
+test_that("`reforge('SBF')` preserves swimbladder profile shape on body resize", {
+  data(sardine, package = "acousticTS")
+
+  orig_body <- extract(sardine, "body")$rpos
+  orig_bladder <- extract(sardine, "bladder")$rpos
+  scale_factor <- 0.5
+
+  resized <- reforge(sardine, body_scale = scale_factor)
+  new_bladder <- extract(resized, "bladder")$rpos
+
+  orig_center <- (orig_bladder[3, ] + orig_bladder[4, ]) / 2
+  new_center <- (new_bladder[3, ] + new_bladder[4, ]) / 2
+  orig_height <- orig_bladder[3, ] - orig_bladder[4, ]
+  new_height <- new_bladder[3, ] - new_bladder[4, ]
+
+  expect_equal(
+    new_center - mean(new_center),
+    (orig_center - mean(orig_center)) * scale_factor,
+    tolerance = 1e-10
+  )
+  expect_equal(new_height, orig_height * scale_factor, tolerance = 1e-10)
+  expect_equal(
+    .reforge_relative_vertical_offset(orig_bladder, orig_body),
+    .reforge_relative_vertical_offset(
+      new_bladder,
+      extract(resized, "body")$rpos
+    ),
+    tolerance = 1e-8
+  )
+})
+
 test_that("`reforge('GAS')` reshapes canonical bodies and stays a GAS", {
   prolate <- gas_generate(
     shape = prolate_spheroid(


### PR DESCRIPTION
This applies fixes to a few bugs encountered when using the `reforge` method for `SBF`- and `BBF`-class `Scatterer` objects.